### PR TITLE
2017-4-17 Software version upgrade

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -123,6 +123,7 @@ scalacOptions ++= Seq(
   "-P:clippy:colors=true"
 )
 
+bashScriptExtraDefines += """addJava "-Dnetworkaddress.cache.ttl=60""""
 bashScriptExtraDefines ++= Seq("""addApp "-log.level=$"$"${LOG_LEVEL}"""",
                                s"""addApp "-service.version=$"$"${version.value}"""")
 

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -4,7 +4,7 @@ organization=com.example
 package=$organization$.$name;format="norm,word"$
 service_version=0.0.1-SNAPSHOT
 scala_version=2.11.8
-sbt_version=0.13.13
+sbt_version=0.13.15
 verbatim=*.md *.jar
 docker_package_name=finatra-sample-service
 service_tags=vr,service


### PR DESCRIPTION
+ Upgraded the default sbt version from 0.13.13 to 0.13.15
+ Added `networkaddress.cache.ttl=60` to eliminate the case of indefinitely cached DNS resolving result