### PR TITLE
Remove `-XX:+UseCGroupMemoryLimitForHeap` as it's deprecated in Java 8

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -202,7 +202,6 @@ bashScriptExtraDefines ++= Seq("""addJava "-server"""",
                                """addJava "-XX:+UnlockExperimentalVMOptions"""",
                                """addJava "-XX:+EnableJVMCI"""",
                                """addJava "-XX:+UseJVMCICompiler"""",
-                               """addJava "-XX:+UseCGroupMemoryLimitForHeap"""",
                                """addJava "-XX:+UseG1GC"""",
                                """addJava "-XX:+UseStringDeduplication"""")
 bashScriptExtraDefines ++= Seq("""addApp "-log.level=$"$"${LOG_LEVEL:-INFO}"""",


### PR DESCRIPTION
Remove `-XX:+UseCGroupMemoryLimitForHeap` as it's deprecated in Java 8, incompatible with Java 12, and doesn't match current requirements.

(Retain `-XX:+UnlockExperimentalVMOptions` as that is also required for the JVMCI flags, and is future compatible)